### PR TITLE
Suggested modifications for Task model

### DIFF
--- a/src/aind_behavior_curriculum/behavior.py
+++ b/src/aind_behavior_curriculum/behavior.py
@@ -1,7 +1,9 @@
 """
 Base Behavior Models
 """
+from __future__ import annotations
 
+from functools import partial
 from typing import Generic, TypeVar
 from enum import Enum
 from pydantic import BaseModel, ConfigDict, Field
@@ -59,3 +61,26 @@ class Task(AindBehaviorModel, Generic[GenericType]):
                 setattr(self, key, value)
             except Exception as e:
                 raise e
+
+
+class AllowModification(Enum):
+    """
+    Enum class representing the options for allowing modification.
+
+    Attributes:
+        TRUE: Represents the option to allow modification (True).
+        FALSE: Represents the option to disallow modification (False).
+    """
+
+    TRUE = True
+    FALSE = False
+
+    def __str__(self):
+        return str(self.value)
+
+    def __repr__(self):
+        return str(self.value)
+
+
+ModifiableAttr = partial(Field, allow_modification=AllowModification.TRUE)
+ModifiableAttr.__doc__ = "Tags a property as modifiable."

--- a/src/aind_behavior_curriculum/behavior.py
+++ b/src/aind_behavior_curriculum/behavior.py
@@ -2,7 +2,16 @@
 Base Behavior Models
 """
 
+from typing import Generic, TypeVar
+from enum import Enum
 from pydantic import BaseModel, ConfigDict, Field
+
+
+class GenericModel(BaseModel, extra="allow"):
+    pass
+
+
+GenericType = TypeVar("GenericType", bound=GenericModel)
 
 
 class AindBehaviorModel(BaseModel):
@@ -28,7 +37,7 @@ class AindBehaviorModel(BaseModel):
     )
 
 
-class Task(AindBehaviorModel):
+class Task(AindBehaviorModel, Generic[GenericType]):
     """
     Set of parameters associated with a mouse task.
     Task parameters may be updated and are revalidated on assignment.
@@ -36,6 +45,7 @@ class Task(AindBehaviorModel):
 
     name: str = Field(..., description="Name of the task.", frozen=True)
     description: str = Field("", description="Description of the task.")
+    task_parameters: GenericType = Field(..., description="Task parameters.", )
 
     def update_parameters(self, **kwargs) -> None:
         """

--- a/src/aind_behavior_curriculum/behavior.py
+++ b/src/aind_behavior_curriculum/behavior.py
@@ -45,6 +45,7 @@ class Task(AindBehaviorModel, Generic[GenericType]):
 
     name: str = Field(..., description="Name of the task.", frozen=True)
     description: str = Field("", description="Description of the task.")
+    version: str = Field(..., description="Version of the task.") # I would prefer using this: https://github.com/AllenNeuralDynamics/Aind.Behavior.MouseUniversity/blob/1ea05884ac58276c72ab01bcc069f0de8c62e281/src/aind_behavior_mouse_university/base/__init__.py#L37
     task_parameters: GenericType = Field(..., description="Task parameters.", )
 
     def update_parameters(self, **kwargs) -> None:


### PR DESCRIPTION
This PR adds a few suggestions to the Task model. 
The most important one is the ability to "overload" the `task_parameters` property with a user-created model. This strategy allows the base class to remain with the `extra="forbid"` while allowing `Child -> Base -> Child` deserialization. 
An example:

```python
from aind_behavior_curriculum.behavior import (
    Task,
    ModifiableAttr,
    GenericModel,
)
from pydantic import Field
from typing import Literal, ClassVar, get_args


class Foo(GenericModel):
    param1: int = Field(default=1, description="This is a property")
    prop1: int = Field(default=1, description="This is a property")
    prop2: str = ModifiableAttr(
        default="a", description="This is another property"
    )


_version = Literal["0.1.0"]


class MyTask(Task):
    version: _version = get_args(_version)[0]
    task_parameters: Foo = Field(
        default=Foo(), description="Task parameters.", validate_default=True
    )


# Notice the modifiable tag when modeling as a json-schema
# The tag can be leveraged by the specific application to allow/disallow modification
# while remaining "on-curriculum"
print(MyTask.model_json_schema())

instance = MyTask(name="Task", task_parameters=Foo(prop1=2))
print(instance)
# name='Task' description='' version='0.1.0' task_parameters=Foo(param1=1, prop1=2, prop2='a')

instance_json = instance.model_dump_json()
print(instance_json)
# {"name":"Task","description":"","version":"0.1.0","task_parameters":{"param1":1,"prop1":2,"prop2":"a"}}

instance_parent = Task.model_validate_json(instance_json)
print(instance_parent)
# name='Task' description='' version='0.1.0' task_parameters=GenericModel(param1=1, prop1=2, prop2='a')

instance_prime = MyTask.model_validate_json(instance_parent.model_dump_json())
print(instance_prime == instance)
# True

```