### PR TITLE
Refactor docs table of contents 

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,6 +3,7 @@ exclude =
     .git,
     __pycache__,
     build,
-    examples/
+    examples/,
+    src/aind_behavior_curriculum/__init__.py
 max-complexity = 10
 max-line-length = 90

--- a/docs/source/aind_behavior_curriculum.rst
+++ b/docs/source/aind_behavior_curriculum.rst
@@ -1,71 +1,15 @@
 aind\_behavior\_curriculum package
 ==================================
 
-Submodules
-----------
+aind_behavior_curriculum
+-------------
 
-aind\_behavior\_curriculum.curriculum module
---------------------------------------------
+.. toctree::
+   :maxdepth: 1
 
-.. autoclass:: aind_behavior_curriculum.curriculum.BehaviorGraph
-   :members:
-   :undoc-members:
-   :show-inheritance:
-   :no-index:
+   aind_behavior_curriculum/base
+   aind_behavior_curriculum/curriculum
+   aind_behavior_curriculum/task
+   aind_behavior_curriculum/trainer
+   aind_behavior_curriculum/curriculum_utils
 
-.. autoclass:: aind_behavior_curriculum.curriculum.Metrics
-   :show-inheritance:
-
-.. autoclass:: aind_behavior_curriculum.curriculum.Rule
-   :show-inheritance:
-
-.. autoclass:: aind_behavior_curriculum.curriculum.Policy
-   :members: rule, validate_rule
-   :show-inheritance:
-
-.. autoclass:: aind_behavior_curriculum.curriculum.PolicyTransition
-   :members: rule, validate_rule
-   :show-inheritance:
-
-.. autoclass:: aind_behavior_curriculum.curriculum.Stage
-   :members: add_policy, add_policy_transition, get_task_parameters, graph, name, remove_policy, remove_policy_transition, see_policies, see_policy_transitions, set_policy_transition_priority, set_start_policies, set_task_parameters, start_policies, task, validate_stage
-   :show-inheritance:
-
-.. autoclass:: aind_behavior_curriculum.curriculum.StageTransition
-   :members: rule, validate_rule
-   :show-inheritance:
-
-.. autoclass:: aind_behavior_curriculum.curriculum.StageGraph
-   :show-inheritance:
-
-.. autoclass:: aind_behavior_curriculum.curriculum.Curriculum
-   :members: add_stage, add_stage_transition, download_curriculum, export_curriculum, export_diagram, export_json, graph, name, pkg_location, remove_stage, remove_stage_transition, see_stage_transitions, see_stages, set_stage_transition_priority, validate_curriculum
-   :show-inheritance:
-
-aind\_behavior\_curriculum.curriculum\_utils module
----------------------------------------------------
-
-.. automodule:: aind_behavior_curriculum.curriculum_utils
-   :members:
-   :show-inheritance:
-
-aind\_behavior\_curriculum.task module
---------------------------------------
-
-.. automodule:: aind_behavior_curriculum.task
-   :members:
-   :show-inheritance:
-
-aind\_behavior\_curriculum.trainer module
------------------------------------------
-
-.. automodule:: aind_behavior_curriculum.trainer
-   :members:
-   :show-inheritance:
-
-Module contents
----------------
-
-.. automodule:: aind_behavior_curriculum
-   :members:
-   :show-inheritance:

--- a/docs/source/aind_behavior_curriculum/base.rst
+++ b/docs/source/aind_behavior_curriculum/base.rst
@@ -1,0 +1,10 @@
+base
+--------------------------------------------
+
+.. automodule:: aind_behavior_curriculum.base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+

--- a/docs/source/aind_behavior_curriculum/curriculum.rst
+++ b/docs/source/aind_behavior_curriculum/curriculum.rst
@@ -1,0 +1,9 @@
+curriculum
+--------------------------------------------
+
+.. automodule:: aind_behavior_curriculum.curriculum
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+

--- a/docs/source/aind_behavior_curriculum/curriculum_utils.rst
+++ b/docs/source/aind_behavior_curriculum/curriculum_utils.rst
@@ -1,0 +1,9 @@
+curriculum_utils
+--------------------------------------------
+
+.. automodule:: aind_behavior_curriculum.curriculum_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+

--- a/docs/source/aind_behavior_curriculum/task.rst
+++ b/docs/source/aind_behavior_curriculum/task.rst
@@ -1,0 +1,9 @@
+task
+--------------------------------------------
+
+.. automodule:: aind_behavior_curriculum.task
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+

--- a/docs/source/aind_behavior_curriculum/trainer.rst
+++ b/docs/source/aind_behavior_curriculum/trainer.rst
@@ -1,0 +1,9 @@
+trainer
+--------------------------------------------
+
+.. automodule:: aind_behavior_curriculum.trainer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from aind_behavior_curriculum import __version__ as package_version
 
 INSTITUTE_NAME = "Allen Institute for Neural Dynamics"
+SOURCE_ROOT = "https://github.com/AllenNeuralDynamics/aind-behavior-curriculum/tree/main/src/"
 
 current_year = date.today().year
 
@@ -34,7 +35,12 @@ extensions = [
     "sphinxcontrib.autodoc_pydantic",
     # "autoapi.extension",
     "sphinx.ext.napoleon",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.linkcode",
 ]
+
+
 templates_path = ["_templates"]
 exclude_patterns = []
 
@@ -57,3 +63,12 @@ html_show_sphinx = False
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 html_show_copyright = False
+
+# -- Options for linkcode extension ------------------------------------------
+def linkcode_resolve(domain, info):
+    if domain != "py":
+        return None
+    if not info["module"]:
+        return None
+    filename = info["module"].replace(".", "/")
+    return f"{SOURCE_ROOT}/{filename}.py"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from aind_behavior_curriculum import __version__ as package_version
 
 INSTITUTE_NAME = "Allen Institute for Neural Dynamics"
-SOURCE_ROOT = "https://github.com/AllenNeuralDynamics/aind-behavior-curriculum/tree/main/src/"
+SOURCE_ROOT = "https://github.com/AllenNeuralDynamics/aind-behavior-curriculum/tree/main/src/"  # noqa: E501
 
 current_year = date.today().year
 
@@ -63,6 +63,7 @@ html_show_sphinx = False
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 html_show_copyright = False
+
 
 # -- Options for linkcode extension ------------------------------------------
 def linkcode_resolve(domain, info):

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -161,9 +161,9 @@ time. Define all the **Tasks/Stages/Stage Transitions** associated
 with the higher level graph, and then move onto defining the
 **Policies/Policy Transitions** associated with each **Stage**.
 
--  **Metrics** contains all the variables that trigger conditions
+-  :py:class:`aind_behavior_curriculum.curriculum.Metrics` contains all the variables that trigger conditions
    associated with **Stage Transitions** and
-   **Policy Transitions**. Progressively add to **Metrics** as
+   **Policy Transitions**. Progressively add to :py:class:`aind_behavior_curriculum.curriculum.Metrics` as
    needed.
 
 -  Keep **Stage Transitions** and **Policy Transitions** simple.
@@ -189,6 +189,20 @@ curriculum_utils.GRADUATED.
    PolicyTransition.validate_rule(...)/StageTransition.validate_rule(...)
 
 :math:`~`
+
+
+A word on `Metrics`
+------------------
+
+:py:class:`~aind_behavior_curriculum.curriculum.Metrics` used in the curriculum should follow the following general principles:
+
+-  :py:class:`~aind_behavior_curriculum.curriculum.Metrics` should be simple and cheap to calculate. A :py:class:`aind_behavior_curriculum.curriculum.Metrics` should represent a
+   single variable that can be used to trigger a **Stage Transition** or **Policy Transition**. For example, a metric could be 'time spent in stage', 'distance traveled', or 'number of licks'.
+
+- :py:class:`aind_behavior_curriculum.curriculum.Metrics` should be calculated as soon as the data is acquired, ideally at the rig.
+
+- While the calculation of these metrics will be largely up to the user, we strongly encourage users to maintain a single method that is used to solely return the populated model. This will make it easier to maintain and update the metrics as needed, without incurring in extra dependencies (e.g. plotting libraries, etc.).
+
 
 Building a Trainer
 ------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -227,7 +227,7 @@ Trainer cannot be defined.
    :maxdepth: 2
    :caption: Contents:
 
-   modules
+   aind_behavior_curriculum
 
 
 Indices and tables
@@ -236,3 +236,5 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
+
+

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,7 +1,0 @@
-src
-===
-
-.. toctree::
-   :maxdepth: 4
-
-   aind_behavior_curriculum

--- a/src/aind_behavior_curriculum/__init__.py
+++ b/src/aind_behavior_curriculum/__init__.py
@@ -6,10 +6,7 @@ Modules in this file are public facing.
 
 __version__ = "0.0.20"
 
-from .task import (
-    Task,
-    TaskParameters
-) # noqa: F401, F403
+from .task import Task, TaskParameters
 
 from .curriculum import (
     Metrics,
@@ -19,12 +16,9 @@ from .curriculum import (
     Stage,
     StageGraph,
     StageTransition,
-    Curriculum
-)  # noqa: F401, F403
+    Curriculum,
+)
 
-from .curriculum_utils import *  # noqa: F401, F403
+from .curriculum_utils import *
 
-from .trainer import (
-    SubjectHistory,
-    Trainer
-)  # noqa: F401, F403
+from .trainer import SubjectHistory, Trainer

--- a/src/aind_behavior_curriculum/curriculum.py
+++ b/src/aind_behavior_curriculum/curriculum.py
@@ -20,12 +20,9 @@ from pydantic_core import core_schema
 
 from aind_behavior_curriculum.base import (
     AindBehaviorModel,
-    AindBehaviorModelExtra
+    AindBehaviorModelExtra,
 )
-from aind_behavior_curriculum.task import (
-    Task,
-    TaskParameters
-)
+from aind_behavior_curriculum.task import Task, TaskParameters
 
 TTask = TypeVar("TTask", bound=Task)
 
@@ -1031,12 +1028,14 @@ class Curriculum(AindBehaviorModel):
                 Dictionary with the json content
             """
 
-            s3 = boto3.client('s3')
+            s3 = boto3.client("s3")
             response = s3.get_object(Bucket=bucket_name, Key=json_key)
-            json_data = json.loads(response['Body'].read().decode('utf-8'))
+            json_data = json.loads(response["Body"].read().decode("utf-8"))
             return json_data
 
-        json_dict = read_json(bucket, str(Path("curriculums") / name / version / 'schema.json'))
+        json_dict = read_json(
+            bucket, str(Path("curriculums") / name / version / "schema.json")
+        )  # noqa: E501
         json_string = json.dumps(json_dict)
         curr = cls.model_validate_json(json_string)
 

--- a/src/aind_behavior_curriculum/curriculum_utils.py
+++ b/src/aind_behavior_curriculum/curriculum_utils.py
@@ -6,15 +6,9 @@ from typing import Annotated, Literal, Union
 
 from pydantic import Field
 
-from aind_behavior_curriculum.curriculum import (
-    Metrics,
-    Policy,
-    Stage
-)
-from aind_behavior_curriculum.task import (
-    Task,
-    TaskParameters
-)
+from aind_behavior_curriculum.curriculum import Metrics, Policy, Stage
+from aind_behavior_curriculum.task import Task, TaskParameters
+
 
 def get_task_types():
     """

--- a/src/aind_behavior_curriculum/trainer.py
+++ b/src/aind_behavior_curriculum/trainer.py
@@ -8,18 +8,14 @@ from typing import List, Optional, Tuple, TypeAlias
 
 from pydantic import Field
 
-from aind_behavior_curriculum.base import (
-    AindBehaviorModel,
-)
+from aind_behavior_curriculum.base import AindBehaviorModel
 from aind_behavior_curriculum.curriculum import (
     Curriculum,
     Metrics,
     Policy,
     Stage,
 )
-from aind_behavior_curriculum.task import (
-    TaskParameters
-)
+from aind_behavior_curriculum.task import TaskParameters
 
 Stage_Entry: TypeAlias = Stage | None
 Policy_Entry: TypeAlias = Tuple[Policy, ...] | None
@@ -34,7 +30,9 @@ class SubjectHistory(AindBehaviorModel):
     """
 
     stage_history: list[Stage_Entry] = Field(default=[], validate_default=True)
-    policy_history: list[Policy_Entry] = Field(default=[], validate_default=True)
+    policy_history: list[Policy_Entry] = Field(
+        default=[], validate_default=True
+    )
 
     def add_entry(self, stage: Stage_Entry, policies: Policy_Entry) -> None:
         """


### PR DESCRIPTION
This pull request refactors the current docs by:

- Changing the toc structure to separate modules by page, attempting to improve readability
- Favor automodule instead of explicit calls to methods and classes for less future maintenance costs
- Adds guidelines for Metrics calculation
- Adds an example on how to cross reference modules/classes in the conceptual documentation (also see #24)
- Adds automatic generation of links to source code