### PR TITLE
Add reference of metrics constructor to Stage object

### DIFF
--- a/examples/example_project/curriculum.py
+++ b/examples/example_project/curriculum.py
@@ -67,7 +67,7 @@ def stageA_policyA_rule(
     return task_params
 
 
-stageA_policyA = Policy(rule=stageA_policyA_rule)
+stageA_policyA = Policy(stageA_policyA_rule)
 
 
 def stageA_policyB_rule(
@@ -78,7 +78,7 @@ def stageA_policyB_rule(
     return task_params
 
 
-stageA_policyB = Policy(rule=stageA_policyB_rule)
+stageA_policyB = Policy(stageA_policyB_rule)
 
 
 def stageB_policyA_rule(
@@ -89,7 +89,7 @@ def stageB_policyA_rule(
     return task_params
 
 
-stageB_policyA = Policy(rule=stageB_policyA_rule)
+stageB_policyA = Policy(stageB_policyA_rule)
 
 
 def stageB_policyB_rule(
@@ -100,7 +100,7 @@ def stageB_policyB_rule(
     return task_params
 
 
-stageB_policyB = Policy(rule=stageB_policyB_rule)
+stageB_policyB = Policy(stageB_policyB_rule)
 
 
 # --- POLICY TRANSTITIONS ---
@@ -108,28 +108,28 @@ def t1_5_rule(metrics: ExampleMetrics) -> bool:
     return metrics.theta_1 > 5
 
 
-t1_5 = PolicyTransition(rule=t1_5_rule)
+t1_5 = PolicyTransition(t1_5_rule)
 
 
 def t1_10_rule(metrics: ExampleMetrics) -> bool:
     return metrics.theta_1 > 10
 
 
-t1_10 = PolicyTransition(rule=t1_10_rule)
+t1_10 = PolicyTransition(t1_10_rule)
 
 
 def t3_5_rule(metrics: ExampleMetrics) -> bool:
     return metrics.theta_3 > 5
 
 
-t3_5 = PolicyTransition(rule=t3_5_rule)
+t3_5 = PolicyTransition(t3_5_rule)
 
 
 def t3_10_rule(metrics: ExampleMetrics) -> bool:
     return metrics.theta_3 > 10
 
 
-t3_10 = PolicyTransition(rule=t3_10_rule)
+t3_10 = PolicyTransition(t3_10_rule)
 
 
 # --- STAGE TRANSITIONS ---
@@ -137,14 +137,14 @@ def t2_5_rule(metrics: ExampleMetrics) -> bool:
     return metrics.theta_2 > 5
 
 
-t2_5 = StageTransition(rule=t2_5_rule)
+t2_5 = StageTransition(t2_5_rule)
 
 
 def t2_10_rule(metrics: ExampleMetrics) -> bool:
     return metrics.theta_2 > 10
 
 
-t2_10 = StageTransition(rule=t2_10_rule)
+t2_10 = StageTransition(t2_10_rule)
 
 
 # --- CURRICULUM ---

--- a/examples/example_project_2/curriculum.py
+++ b/examples/example_project_2/curriculum.py
@@ -56,7 +56,7 @@ def policy_1_rule(
     return task_params
 
 
-policy_1 = Policy(rule=policy_1_rule)
+policy_1 = Policy(policy_1_rule)
 
 
 def policy_2_rule(
@@ -67,7 +67,7 @@ def policy_2_rule(
     return task_params
 
 
-policy_2 = Policy(rule=policy_2_rule)
+policy_2 = Policy(policy_2_rule)
 
 
 def policy_3_rule(
@@ -78,7 +78,7 @@ def policy_3_rule(
     return task_params
 
 
-policy_3 = Policy(rule=policy_3_rule)
+policy_3 = Policy(policy_3_rule)
 
 
 def policy_4_rule(
@@ -89,7 +89,7 @@ def policy_4_rule(
     return task_params
 
 
-policy_4 = Policy(rule=policy_4_rule)
+policy_4 = Policy(policy_4_rule)
 
 
 def policy_5_rule(
@@ -100,7 +100,7 @@ def policy_5_rule(
     return task_params
 
 
-policy_5 = Policy(rule=policy_5_rule)
+policy_5 = Policy(policy_5_rule)
 
 
 def policy_6_rule(
@@ -111,7 +111,7 @@ def policy_6_rule(
     return task_params
 
 
-policy_6 = Policy(rule=policy_6_rule)
+policy_6 = Policy(policy_6_rule)
 
 
 # --- POLICY/STAGE TRANSTITIONS ---
@@ -119,16 +119,16 @@ def m1_rule(metrics: ExampleMetrics2) -> bool:
     return metrics.m1 > 0
 
 
-m1_policy_transition = PolicyTransition(rule=m1_rule)
-m1_stage_transition = StageTransition(rule=m1_rule)
+m1_policy_transition = PolicyTransition(m1_rule)
+m1_stage_transition = StageTransition(m1_rule)
 
 
 def m2_rule(metrics: ExampleMetrics2) -> bool:
     return metrics.m2 > 0
 
 
-m2_policy_transition = PolicyTransition(rule=m2_rule)
-m2_stage_transition = StageTransition(rule=m2_rule)
+m2_policy_transition = PolicyTransition(m2_rule)
+m2_stage_transition = StageTransition(m2_rule)
 
 
 # --- CURRICULUM ---

--- a/src/aind_behavior_curriculum/__init__.py
+++ b/src/aind_behavior_curriculum/__init__.py
@@ -11,7 +11,6 @@ from .curriculum import (
     Metrics,
     Policy,
     PolicyTransition,
-    Rule,
     Stage,
     StageGraph,
     StageTransition,

--- a/src/aind_behavior_curriculum/__init__.py
+++ b/src/aind_behavior_curriculum/__init__.py
@@ -9,6 +9,7 @@ __version__ = "0.0.28"
 from .curriculum import (
     Curriculum,
     Metrics,
+    MetricsProvider,
     Policy,
     PolicyTransition,
     Stage,

--- a/src/aind_behavior_curriculum/curriculum.py
+++ b/src/aind_behavior_curriculum/curriculum.py
@@ -150,12 +150,22 @@ class _Rule(Generic[_P, _R]):
             ]
         )
 
+        from_callable_schema = core_schema.chain_schema(
+            [
+                core_schema.callable_schema(),
+                core_schema.no_info_plain_validator_function(
+                    cls._deserialize_rule
+                ),
+            ]
+        )
+
         return core_schema.json_or_python_schema(
             json_schema=from_str_schema,
             python_schema=core_schema.union_schema(
                 [
                     core_schema.is_instance_schema(cls),
                     from_str_schema,
+                    from_callable_schema,
                 ]
             ),
             serialization=core_schema.plain_serializer_function_ser_schema(

--- a/src/aind_behavior_curriculum/curriculum.py
+++ b/src/aind_behavior_curriculum/curriculum.py
@@ -80,9 +80,9 @@ class _Rule(Generic[_P, _R]):
         """
         Initializes a new instance of the class.
         Args:
-            function (Callable[_P, _R]): The function to be used. If an instance of _Rule is passed, 
+            function (Callable[_P, _R]): The function to be used. If an instance of _Rule is passed,
                                          the callable attribute of the _Rule instance will be used.
-            skip_validation (bool, optional): If set to True, skips the validation of the callable's typing. 
+            skip_validation (bool, optional): If set to True, skips the validation of the callable's typing.
                                               Defaults to False.
         Returns:
             None

--- a/src/aind_behavior_curriculum/curriculum.py
+++ b/src/aind_behavior_curriculum/curriculum.py
@@ -1323,8 +1323,6 @@ def make_task_discriminator(tasks: Iterable[Type[Task]]) -> Type:
                 f"Task {task} has a name field that is not a string, got {name} of type {type(name)}"
             )
 
-    if len(_candidate_discriminators) != len(set(_candidate_discriminators)):
-        raise ValueError("Duplicate task names found.")
     if len(_candidate_discriminators) != len(tasks):
         raise ValueError("One of more task names were not found.")
 

--- a/src/aind_behavior_curriculum/curriculum.py
+++ b/src/aind_behavior_curriculum/curriculum.py
@@ -652,6 +652,10 @@ class PolicyGraph(BehaviorGraph[Policy, PolicyTransition]):
     pass
 
 
+class MetricsProvider(_Rule[..., Metrics]):
+    pass
+
+
 class Stage(AindBehaviorModel, Generic[TTask]):
     """
     Instance of a Task.
@@ -670,6 +674,10 @@ class Stage(AindBehaviorModel, Generic[TTask]):
     )
     start_policies: List[Policy] = Field(
         default_factory=list, description="List of starting policies."
+    )
+    metrics_provider: Optional[MetricsProvider] = Field(
+        default=None,
+        description="A MetricsProvider instance that keeps a reference to a handle to create a metrics object for this stage.",
     )
 
     def __eq__(self, other: Any) -> bool:

--- a/src/aind_behavior_curriculum/curriculum.py
+++ b/src/aind_behavior_curriculum/curriculum.py
@@ -77,6 +77,12 @@ class _Rule(Generic[_P, _R]):
     def __init__(
         self, function: Callable[_P, _R], *, skip_validation: bool = False
     ) -> None:
+
+        # Just in case people pass the _Rule instance directly
+        # Instead of the callable
+        if isinstance(function, _Rule):
+            function = function.callable
+
         if not skip_validation:
             self._validate_callable_typing(function)
         self._callable = function

--- a/src/aind_behavior_curriculum/curriculum_utils.py
+++ b/src/aind_behavior_curriculum/curriculum_utils.py
@@ -44,7 +44,7 @@ def init_stage_rule(
     return task_params
 
 
-INIT_STAGE = Policy(rule=init_stage_rule)
+INIT_STAGE = Policy(init_stage_rule)
 
 
 class Graduated(Task):

--- a/src/aind_behavior_curriculum/trainer.py
+++ b/src/aind_behavior_curriculum/trainer.py
@@ -90,8 +90,8 @@ class TrainerState(AindBehaviorModel):
             return False
 
         # Extract Rule callable which is hashable for set equality
-        self_rules = [p.rule for p in self.active_policies]
-        other_rules = [p.rule for p in other.active_policies]
+        self_rules = [p for p in self.active_policies]
+        other_rules = [p for p in other.active_policies]
 
         return set(self_rules) == set(other_rules)
 
@@ -199,7 +199,7 @@ class Trainer(Generic[TCurriculum]):
         stage_transitions = curriculum.see_stage_transitions(current_stage)
         for stage_eval, dest_stage in stage_transitions:
             # On the first (and only first) true evaluation we transition.
-            if stage_eval.rule(metrics):  # type: ignore
+            if stage_eval(metrics):  # type: ignore
                 updated_stage = dest_stage
                 break
         return updated_stage
@@ -232,7 +232,7 @@ class Trainer(Generic[TCurriculum]):
             for policy_eval, dest_policy in policy_transitions:
                 # On first true evaluation, add to buffers
                 # and evaluate next active_policy.
-                if policy_eval.rule(metrics):  # type: ignore
+                if policy_eval(metrics):  # type: ignore
                     dest_policies.append(dest_policy)
                     _has_transitioned = True
                     break  # onto next active policy
@@ -312,7 +312,7 @@ class Trainer(Generic[TCurriculum]):
 
         updated_params = stage_parameters.model_copy(deep=True)
         for p in stage_policies:
-            updated_params = p.rule(curr_metrics, updated_params)
+            updated_params = p(curr_metrics, updated_params)
 
         return updated_params
 
@@ -325,8 +325,8 @@ class Trainer(Generic[TCurriculum]):
         reassembles the Policy objects.
         """
 
-        filtered_funcs = list(set(p.rule for p in policies))
-        output = [Policy(rule=f) for f in filtered_funcs]
+        filtered_funcs = list(set(p for p in policies))
+        output = [Policy(f) for f in filtered_funcs]
 
         return output
 

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -127,3 +127,18 @@ class RuleTests(unittest.TestCase):
         self.assertTrue(
             is_non_deserializable_callable(deser_json.this_new_rule.callable)
         )
+
+    def rule_from_callable(self):
+        container = self.container(this_new_rule=rule_update)
+        dump = container.model_dump()
+        json_dump = container.model_dump_json()
+
+        deser = container.model_validate(dump)
+        deser_json = container.model_validate_json(json_dump)
+
+        self.assertEqual(container, deser)
+        self.assertEqual(container, deser_json)
+
+    def rule_from_not_callable(self):
+        with self.assertRaises(TypeError):
+            _ = self.container(this_new_rule=not_a_rule_update)

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1,0 +1,88 @@
+"""
+Curriculum Test Suite
+"""
+
+import unittest
+from typing import Literal
+
+from pydantic import BaseModel, Field
+from aind_behavior_curriculum.curriculum import _Rule, _NonDeserializableCallable, is_non_deserializable_callable, try_materialize_non_deserializable_callable_error
+from aind_behavior_curriculum import Metrics, TaskParameters
+
+
+class RuleTests(unittest.TestCase):
+
+    def setUp(self):
+
+        def rule_update(metrics: Metrics, params: TaskParameters) -> TaskParameters:
+            return params
+
+        def duck_type_rule_update(m, p):
+            return p
+
+        def not_a_rule_update(metrics: int, params: BaseModel) -> BaseModel:
+            return params
+
+        class CustomRule(_Rule[[Metrics, TaskParameters], TaskParameters]):
+            pass
+
+        class Container(BaseModel):
+            this_new_rule: CustomRule = Field(default=CustomRule(rule_update))
+
+        self.rule_update = rule_update
+        self.duck_type_rule_update = duck_type_rule_update
+        self.not_a_rule_update = not_a_rule_update
+        self.container = Container
+        self.custom_rule = CustomRule
+
+    def test_rule_instantiation(self):
+        self.container(this_new_rule=self.custom_rule(self.rule_update))
+
+    def test_duck_type_rule_instantiation(self):
+        self.container(this_new_rule=self.custom_rule(self.duck_type_rule_update))
+
+    def test_not_a_rule_instantiation(self):
+        with self.assertRaises(TypeError):
+            self.container(this_new_rule=self.custom_rule(self.not_a_rule_update))
+
+
+    def test_can_serialize_rule(self):
+        container = self.container(this_new_rule=self.custom_rule(self.rule_update))
+        container.model_dump()
+        container.model_dump_json()
+
+    def test_can_deserialize_rule(self):
+        container = self.container(this_new_rule=self.custom_rule(self.rule_update))
+        dump = container.model_dump()
+        self.assertEqual(dump, container.model_validate(dump))
+        json_dump = container.model_dump_json()
+        self.assertEqual(json_dump, container.model_validate_json(json_dump))
+
+    def test_is_non_deserializable_callable(self):
+        callable_ref = _NonDeserializableCallable("test", Exception("test"))
+        with self.assertRaises(RuntimeError):
+            callable_ref()
+        self.assertFalse(is_non_deserializable_callable(self.custom_rule(self.rule_update)))
+        self.assertTrue(is_non_deserializable_callable(callable_ref))
+
+        self.assertIsInstance(try_materialize_non_deserializable_callable_error(callable_ref), Exception)
+        self.assertIsNone(try_materialize_non_deserializable_callable_error(self.custom_rule(self.rule_update)))
+
+    def test_can_deserialize_rule(self):
+        def rule_update_to_be_deleted(metrics: Metrics, params: TaskParameters) -> TaskParameters:
+            return params
+
+        def back_rule_update(metrics: Metrics, params: TaskParameters) -> TaskParameters:
+            return params
+
+        container = self.container(this_new_rule=self.custom_rule(rule_update_to_be_deleted))
+        dump = container.model_dump()
+        json_dump = container.model_dump_json()
+
+        del rule_update_to_be_deleted
+
+        deser = container.model_validate(dump)
+        deser_json = container.model_validate_json(json_dump)
+
+        self.assertTrue(is_non_deserializable_callable(deser.this_new_rule.callable))
+        self.assertTrue(is_non_deserializable_callable(deser_json.this_new_rule.callable))

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -3,18 +3,25 @@ Curriculum Test Suite
 """
 
 import unittest
-from typing import Literal
 
 from pydantic import BaseModel, Field
-from aind_behavior_curriculum.curriculum import _Rule, _NonDeserializableCallable, is_non_deserializable_callable, try_materialize_non_deserializable_callable_error
+
 from aind_behavior_curriculum import Metrics, TaskParameters
+from aind_behavior_curriculum.curriculum import (
+    _NonDeserializableCallable,
+    _Rule,
+    is_non_deserializable_callable,
+    try_materialize_non_deserializable_callable_error,
+)
 
 
 class RuleTests(unittest.TestCase):
 
     def setUp(self):
 
-        def rule_update(metrics: Metrics, params: TaskParameters) -> TaskParameters:
+        def rule_update(
+            metrics: Metrics, params: TaskParameters
+        ) -> TaskParameters:
             return params
 
         def duck_type_rule_update(m, p):
@@ -39,20 +46,27 @@ class RuleTests(unittest.TestCase):
         self.container(this_new_rule=self.custom_rule(self.rule_update))
 
     def test_duck_type_rule_instantiation(self):
-        self.container(this_new_rule=self.custom_rule(self.duck_type_rule_update))
+        self.container(
+            this_new_rule=self.custom_rule(self.duck_type_rule_update)
+        )
 
     def test_not_a_rule_instantiation(self):
         with self.assertRaises(TypeError):
-            self.container(this_new_rule=self.custom_rule(self.not_a_rule_update))
-
+            self.container(
+                this_new_rule=self.custom_rule(self.not_a_rule_update)
+            )
 
     def test_can_serialize_rule(self):
-        container = self.container(this_new_rule=self.custom_rule(self.rule_update))
+        container = self.container(
+            this_new_rule=self.custom_rule(self.rule_update)
+        )
         container.model_dump()
         container.model_dump_json()
 
     def test_can_deserialize_rule(self):
-        container = self.container(this_new_rule=self.custom_rule(self.rule_update))
+        container = self.container(
+            this_new_rule=self.custom_rule(self.rule_update)
+        )
         dump = container.model_dump()
         self.assertEqual(dump, container.model_validate(dump))
         json_dump = container.model_dump_json()
@@ -62,20 +76,35 @@ class RuleTests(unittest.TestCase):
         callable_ref = _NonDeserializableCallable("test", Exception("test"))
         with self.assertRaises(RuntimeError):
             callable_ref()
-        self.assertFalse(is_non_deserializable_callable(self.custom_rule(self.rule_update)))
+        self.assertFalse(
+            is_non_deserializable_callable(self.custom_rule(self.rule_update))
+        )
         self.assertTrue(is_non_deserializable_callable(callable_ref))
 
-        self.assertIsInstance(try_materialize_non_deserializable_callable_error(callable_ref), Exception)
-        self.assertIsNone(try_materialize_non_deserializable_callable_error(self.custom_rule(self.rule_update)))
+        self.assertIsInstance(
+            try_materialize_non_deserializable_callable_error(callable_ref),
+            Exception,
+        )
+        self.assertIsNone(
+            try_materialize_non_deserializable_callable_error(
+                self.custom_rule(self.rule_update)
+            )
+        )
 
-    def test_can_deserialize_rule(self):
-        def rule_update_to_be_deleted(metrics: Metrics, params: TaskParameters) -> TaskParameters:
+    def test_can_deserialize_rule_reference(self):
+        def rule_update_to_be_deleted(
+            metrics: Metrics, params: TaskParameters
+        ) -> TaskParameters:
             return params
 
-        def back_rule_update(metrics: Metrics, params: TaskParameters) -> TaskParameters:
+        def back_rule_update(
+            metrics: Metrics, params: TaskParameters
+        ) -> TaskParameters:
             return params
 
-        container = self.container(this_new_rule=self.custom_rule(rule_update_to_be_deleted))
+        container = self.container(
+            this_new_rule=self.custom_rule(rule_update_to_be_deleted)
+        )
         dump = container.model_dump()
         json_dump = container.model_dump_json()
 
@@ -84,5 +113,9 @@ class RuleTests(unittest.TestCase):
         deser = container.model_validate(dump)
         deser_json = container.model_validate_json(json_dump)
 
-        self.assertTrue(is_non_deserializable_callable(deser.this_new_rule.callable))
-        self.assertTrue(is_non_deserializable_callable(deser_json.this_new_rule.callable))
+        self.assertTrue(
+            is_non_deserializable_callable(deser.this_new_rule.callable)
+        )
+        self.assertTrue(
+            is_non_deserializable_callable(deser_json.this_new_rule.callable)
+        )


### PR DESCRIPTION
> [!NOTE]
> This PR should be reviewed after #57

The use case goes like this:


```python

from pydantic import BaseModel, Field
from typing import Type, TypeVar, ParamSpec, Any
from aind_behavior_curriculum.curriculum import _Rule
from aind_behavior_curriculum import (
    Metrics,
    Stage,
    Task,
    TaskParameters,
    MetricsProvider,
)


class TheseMetrics(Metrics):
    a: int = 1
    b: int = 2


def get_metrics() -> TheseMetrics:
    return TheseMetrics()


foo = Stage(
    name="a",
    task=Task(name="a", task_parameters=TaskParameters()),
    metrics_provider=MetricsProvider(get_metrics),
)

metrics = foo.metrics_provider()
print(metrics)

baz = Stage.model_validate_json(foo.model_dump_json())

metrics = foo.metrics_provider()
print(metrics)
```

Closes #59