### PR TITLE
Use class method `model_fields` instead of instance's 

### DIFF
--- a/src/aind_behavior_curriculum/curriculum.py
+++ b/src/aind_behavior_curriculum/curriculum.py
@@ -929,7 +929,7 @@ class Curriculum(AindBehaviorModel, Generic[TTask]):
         """Get all known tasks in the curriculum."""
 
         # We introspect into the StageGraph[T] type to get the known tasks.
-        _generic = self.model_fields["graph"].annotation
+        _generic = type(self).model_fields["graph"].annotation
         _inner_args = _generic.__dict__["__pydantic_generic_metadata__"]["args"]
 
         _inner_union: Type


### PR DESCRIPTION
Following [pydantic's recommendation](https://docs.pydantic.dev/latest/api/base_model/#pydantic.BaseModel.model_fields):

> Accessing this attribute from a model instance is deprecated, and will not work in Pydantic V3. Instead, you should access this attribute from the model class.

